### PR TITLE
feat: add support for LittleFS subtype

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -206,6 +206,9 @@ pub enum DataPartitionType {
 
     /// SPIFFS partition
     SpiFfs = 0x82,
+
+    /// LittleFS partition
+    LittleFS = 0x83,
 }
 
 impl TryFrom<u8> for DataPartitionType {
@@ -223,6 +226,7 @@ impl TryFrom<u8> for DataPartitionType {
             0x80 => Self::EspHttpd,
             0x81 => Self::Fat,
             0x82 => Self::SpiFfs,
+            0x83 => Self::LittleFS,
             _ => return Err(PartitionError::InvalidSubType(raw)),
         })
     }


### PR DESCRIPTION
From https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/partition-tables.html:

> `littlefs` (0x83) is for [LittleFS filesystem](https://github.com/littlefs-project/littlefs). See [storage/littlefs](https://github.com/espressif/esp-idf/tree/v5.4/examples/storage/littlefs) example for more details.

I am not sure how best to update the partition table tests; if you could advise me on how that is done, I will add them to this PR.